### PR TITLE
autofoo: add automake-1.12 to autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -311,13 +311,14 @@ AUTOHEADER=`echo $AUTOCONF | sed s/autoconf/autoheader/`
 
 case $REQUIRED_AUTOMAKE_VERSION in
     1.4*) automake_progs="automake-1.4" ;;
-    1.5*) automake_progs="automake-1.11 automake-1.10 automake-1.9 automake-1.8 automake-1.7 automake-1.6 automake-1.5" ;;
-    1.6*) automake_progs="automake-1.11 automake-1.10 automake-1.9 automake-1.8 automake-1.7 automake-1.6" ;;
-    1.7*) automake_progs="automake-1.11 automake-1.10 automake-1.9 automake-1.8 automake-1.7" ;;
-    1.8*) automake_progs="automake-1.11 automake-1.10 automake-1.9 automake-1.8" ;;
-    1.9*) automake_progs="automake-1.11 automake-1.10 automake-1.9" ;;
-    1.10*) automake_progs="automake-1.11 automake-1.10" ;;
-    1.11*) automake_progs="automake-1.11" ;;
+    1.5*) automake_progs="automake-1.12 automake-1.11 automake-1.10 automake-1.9 automake-1.8 automake-1.7 automake-1.6 automake-1.5" ;;
+    1.6*) automake_progs="automake-1.12 automake-1.11 automake-1.10 automake-1.9 automake-1.8 automake-1.7 automake-1.6" ;;
+    1.7*) automake_progs="automake-1.12 automake-1.11 automake-1.10 automake-1.9 automake-1.8 automake-1.7" ;;
+    1.8*) automake_progs="automake-1.12 automake-1.11 automake-1.10 automake-1.9 automake-1.8" ;;
+    1.9*) automake_progs="automake-1.12 automake-1.11 automake-1.10 automake-1.9" ;;
+    1.10*) automake_progs="automake-1.12 automake-1.11 automake-1.10" ;;
+    1.11*) automake_progs="automake-1.12 automake-1.11" ;;
+    1.12*) automake_progs="automake-1.12" ;;
 esac
 version_check automake AUTOMAKE "$automake_progs" $REQUIRED_AUTOMAKE_VERSION \
     "http://ftp.gnu.org/pub/gnu/automake/automake-$REQUIRED_AUTOMAKE_VERSION.tar.gz"


### PR DESCRIPTION
Hi Andy,

Today, I tried building LogJam on my arch system, and due to it the system having automake-1.12, the build broke as it only supports 1.11 in autogen.sh. In this fix, I added the few lines necessary to support automake-1.12.

Let me know if you find an issue with the fix.

Regards,

-- Armen
