### PR TITLE
fix issues when using -Werror=format-security

### DIFF
--- a/protocol/liblivejournal/livejournal/entry.c
+++ b/protocol/liblivejournal/livejournal/entry.c
@@ -419,7 +419,7 @@ lj_entry_new_single_from_result(LJResult *result, GError **err) {
 	}
 
 	if (errs) {
-		g_set_error(err, 0, 0, errs->str);
+		g_set_error_literal(err, 0, 0, errs->str);
 		g_string_free(errs, TRUE);
 	}
 
@@ -847,7 +847,7 @@ lj_entry_from_user_editor(const char *filename, GError **err) {
 	/* g_spawn* would do no good: it disassociates the tty. viva fork! */
 	pid = fork();
 	if (pid < 0) {                 /* fork error */
-		g_set_error(err, G_SPAWN_ERROR, G_SPAWN_ERROR_FORK,
+		g_set_error_literal(err, G_SPAWN_ERROR, G_SPAWN_ERROR_FORK,
 				g_strerror(errno));
 		return NULL;
 	}
@@ -862,7 +862,7 @@ lj_entry_from_user_editor(const char *filename, GError **err) {
 
 	/* parent */
 	if (wait(NULL) != pid) {
-		g_set_error(err, G_SPAWN_ERROR, G_SPAWN_ERROR_FAILED,
+		g_set_error_literal(err, G_SPAWN_ERROR, G_SPAWN_ERROR_FAILED,
 				g_strerror(errno));
 		return NULL;
 	}

--- a/src/cmdline.c
+++ b/src/cmdline.c
@@ -676,7 +676,7 @@ command_dispatch(Cmdline *cmdline, Command *commands, const char *help, int argc
 		return;
 
 	if (g_ascii_strcasecmp(cmdname, "help") == 0) {
-		g_print(help);
+		g_print("%s", help);
 		exit(EXIT_SUCCESS);
 	}
 	for (i = 0; commands && commands[i].cmdname; i++) {

--- a/src/login.c
+++ b/src/login.c
@@ -310,7 +310,7 @@ login_check_lastupdate(GtkWindow *parent, JamAccountLJ *acclj) {
 	}
 	dlg = gtk_message_dialog_new(parent, GTK_DIALOG_DESTROY_WITH_PARENT,
 			GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
-			msg);
+			"%s", msg);
 	g_free(msg);
 	if (gtk_dialog_run(GTK_DIALOG(dlg)) == GTK_RESPONSE_YES)
 		ret = login_run(GTK_WINDOW(dlg), acclj);

--- a/src/music.c
+++ b/src/music.c
@@ -68,7 +68,7 @@ music_command_detect(const char *command, GError **err) {
 		return NULL;
 
 	if (exit_status != 0) {
-		g_set_error(err, MUSIC_ERROR, MUSIC_COMMAND_ERROR, std_err);
+		g_set_error_literal(err, MUSIC_ERROR, MUSIC_COMMAND_ERROR, std_err);
 		g_free(std_err);
 		return NULL;
 	}

--- a/src/network-fork.c
+++ b/src/network-fork.c
@@ -113,7 +113,7 @@ pipe_cb(ForkData *forkdata, gint pipe, GdkInputCondition cond) {
 			waitpid(forkdata->pid, NULL, 0);
 			forkdata->pid = 0;
 			close(pipe);
-			g_set_error(forkdata->err, NET_ERROR, NET_ERROR_GENERIC, buf);
+			g_set_error_literal(forkdata->err, NET_ERROR, NET_ERROR_GENERIC, buf);
 			g_free(buf);
 			gtk_main_quit();
 			break;

--- a/src/network-soup.c
+++ b/src/network-soup.c
@@ -82,7 +82,7 @@ net_post_blocking(const char *url, GSList *headers, GString *post,
 
 	status = soup_session_send_message(session, req);
 	if (status != SOUP_STATUS_OK) {
-		g_set_error(err, NET_ERROR, NET_ERROR_GENERIC,
+		g_set_error_literal(err, NET_ERROR, NET_ERROR_GENERIC,
 			    req->reason_phrase);
 		goto out;
 	}

--- a/src/util-gtk.c
+++ b/src/util-gtk.c
@@ -151,7 +151,7 @@ jam_confirm(GtkWindow *parent, const char *title, const char *msg) {
 	dlg = gtk_message_dialog_new(GTK_WINDOW(parent), 0,
 			GTK_MESSAGE_QUESTION,
 			GTK_BUTTONS_YES_NO,
-			msg);
+			"%s", msg);
 	jam_window_init(GTK_WINDOW(dlg), parent, title, -1, -1);
 	res = (gtk_dialog_run(GTK_DIALOG(dlg)) == GTK_RESPONSE_YES);
 	gtk_widget_destroy(dlg);
@@ -309,7 +309,7 @@ jam_message_va(GtkWindow *parent, MessageType type, gboolean forgettable,
 	/* TODO: switch to jam_dialogs, which are prettier */
 	dlg = gtk_message_dialog_new(parent, 0, msgtype,
 			buttontype,
-			fullmsg);
+			"%s", fullmsg);
 	gtk_window_set_title(GTK_WINDOW(dlg), title);
 	gtk_window_set_transient_for(GTK_WINDOW(dlg), GTK_WINDOW(parent));
 


### PR DESCRIPTION
This change applies the necessary fixes for the code to compile cleanly with -Werror=format-security.
