### PR TITLE
Ensure that called functions are declared, for C99 compatibility

### DIFF
--- a/src/about.c
+++ b/src/about.c
@@ -13,6 +13,7 @@
 #include "icons.h"
 #include "thanks.h"
 #include "spawn.h"
+#include "util-gtk.h"
 
 /* magic number, defines how long the name will stay centered before scrolling off. */
 #define COUNTER_DELAY 20

--- a/src/account.c
+++ b/src/account.c
@@ -11,6 +11,7 @@
 #include "conf_xml.h"
 #include "jam_xml.h"
 #include "account.h"
+#include "util.h"
 
 static GObjectClass *jam_account_parent_class = NULL;
 

--- a/src/checkfriends-gtk.c
+++ b/src/checkfriends-gtk.c
@@ -13,6 +13,7 @@
 #include "spawn.h"
 #include "menu.h"
 #include "settings.h"
+#include "util-gtk.h"
 
 #include "throbber.h"
 #include "checkfriends.h"

--- a/src/checkfriends.c
+++ b/src/checkfriends.c
@@ -23,6 +23,7 @@
 #include "account.h"
 #include "conf.h"
 #include "network.h"
+#include "util.h"
 
 enum {
 	ACCOUNT_CHANGED,

--- a/src/conf.c
+++ b/src/conf.c
@@ -18,6 +18,7 @@
 #include "conf_xml.h"
 #include "conf.h"
 #include "account.h"
+#include "util.h"
 
 Configuration conf;
 Application app;

--- a/src/datesel.c
+++ b/src/datesel.c
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <livejournal/livejournal.h>
+#include "util-gtk.h"
 
 #include "datesel.h"
 

--- a/src/draftstore.c
+++ b/src/draftstore.c
@@ -23,6 +23,7 @@
 
 #include "draftstore.h"
 #include "conf.h"
+#include "util.h"
 
 struct _DraftStore {
 	char *path;

--- a/src/friendedit.c
+++ b/src/friendedit.c
@@ -18,6 +18,7 @@
 #include "conf.h"
 #include "util-gtk.h"
 #include "account.h"
+#include "util.h"
 
 #include "friendedit.h"
 

--- a/src/friendgroupedit.c
+++ b/src/friendgroupedit.c
@@ -18,6 +18,7 @@
 #include "friendgroupedit.h"
 #include "network.h"
 #include "util-gtk.h"
+#include "util.h"
 
 typedef struct {
 	GtkWidget *win;

--- a/src/history_recent.c
+++ b/src/history_recent.c
@@ -14,6 +14,7 @@
 #include "util-gtk.h"
 #include "history.h"
 #include "network.h"
+#include "util.h"
 
 /* how many entries to load each time "load more..." is clicked. */
 #define HISTORY_LOAD_BATCH 20

--- a/src/host.c
+++ b/src/host.c
@@ -13,6 +13,7 @@
 #include "account.h"
 #include "jam_xml.h"
 #include "conf_xml.h"
+#include "util.h"
 
 const char*
 jam_host_get_stock_icon(JamHost *host) {

--- a/src/html_markup.h
+++ b/src/html_markup.h
@@ -20,7 +20,7 @@ void html_mark_blockquote  (JamDoc *doc);
 void html_mark_big         (JamDoc *doc);
 void html_mark_small       (JamDoc *doc);
 void html_mark_superscript (JamDoc *doc);
-void html_mark_sbuscript   (JamDoc *doc);
+void html_mark_subscript   (JamDoc *doc);
 void html_mark_ulist       (JamDoc *doc);
 void html_mark_olist       (JamDoc *doc);
 void html_mark_listitem    (JamDoc *doc);

--- a/src/imagelink.c
+++ b/src/imagelink.c
@@ -10,6 +10,7 @@
 #include "util-gtk.h"
 #include "conf.h"
 #include "jamdoc.h"
+#include "util.h"
 
 typedef struct {
 	GtkWidget *dlg;

--- a/src/jamdoc.c
+++ b/src/jamdoc.c
@@ -14,6 +14,7 @@
 #include "jamdoc.h"
 #include "account.h"
 #include "conf.h"
+#include "util.h"
 
 #ifdef HAVE_GTK
 #include "get_cmd_out.h"

--- a/src/journalstore-sqlite.c
+++ b/src/journalstore-sqlite.c
@@ -12,6 +12,7 @@
 
 #include "conf.h"
 #include "journalstore.h"
+#include "util.h"
 
 struct _JournalStore {
 	JamAccount *account;

--- a/src/link-journal.c
+++ b/src/link-journal.c
@@ -9,6 +9,7 @@
 #include "gtk-all.h"
 #include "jamdoc.h"
 #include "util-gtk.h"
+#include "util.h"
 
 static GtkWidget*
 add_menu_item(GtkMenuShell *ms, const gchar *id, const gchar *text) {

--- a/src/link.c
+++ b/src/link.c
@@ -13,6 +13,7 @@
 #include "util-gtk.h"
 #include "conf.h"
 #include "jamdoc.h"
+#include "util.h"
 
 typedef struct {
 	GtkWidget *dlg;

--- a/src/livejournal.c
+++ b/src/livejournal.c
@@ -14,6 +14,7 @@
 #include "jam_xml.h"
 #include "conf_xml.h"
 #include "network.h"
+#include "util.h"
 
 struct _JamHostLJ {
 	JamHost host;

--- a/src/manager.c
+++ b/src/manager.c
@@ -16,6 +16,7 @@
 #include "checkfriends.h"
 #include "security.h"
 #include "groupedbox.h"
+#include "util.h"
 
 /* manager:
  *  - host

--- a/src/pollcreator.c
+++ b/src/pollcreator.c
@@ -12,6 +12,7 @@
 #include "poll.h"
 #include "pollcreator.h"
 #include "util-gtk.h"
+#include "util.h"
 
 typedef struct _PollDlg PollDlg;
 

--- a/src/security.c
+++ b/src/security.c
@@ -14,6 +14,7 @@
 #include "conf.h"
 #include "network.h"
 #include "icons.h"
+#include "util-gtk.h"
 
 struct _SecMgr {
 	GtkOptionMenu omenu;

--- a/src/settings.c
+++ b/src/settings.c
@@ -25,6 +25,7 @@
 #include "account.h"
 #include "jamview.h"
 #include "lj_dbus.h"
+#include "util.h"
 
 /* what's this?  all of these funny structures in the settings box?
  * well, instead of creating and tearing down all of these widgets, i

--- a/src/spawn.c
+++ b/src/spawn.c
@@ -8,6 +8,7 @@
 
 #include "glib-all.h"
 #include <stdio.h>
+#include "util-gtk.h"
 
 #ifndef G_OS_WIN32
 #include <unistd.h>

--- a/src/tags.c
+++ b/src/tags.c
@@ -3,6 +3,8 @@
  * vim: tabstop=4 shiftwidth=4 noexpandtab :
  */
 
+#include "config.h"
+
 #include "gtk-all.h"
 
 #include <livejournal/livejournal.h>

--- a/src/tie.c
+++ b/src/tie.c
@@ -8,6 +8,7 @@
 
 #include "gtk-all.h"
 #include "util-gtk.h"
+#include "util.h"
 
 static void
 tie_toggle_cb(GtkToggleButton *toggle, gboolean *data) {

--- a/src/tools.c
+++ b/src/tools.c
@@ -12,6 +12,7 @@
 
 #include "tools.h"
 #include "util-gtk.h"
+#include "util.h"
 
 typedef struct {
 	gunichar c;


### PR DESCRIPTION
Include "util.h" for declarations of string_replace, verify_path, xml_escape, and "util-gtk.h" for geometry_tie, jam_win_set_size, jam_warning jam_dialog_set_contents, scroll_wrap.  Include "network.h" for net_ctx_gtk_new.  Fix a type of html_mark_subscript in "html_markup.h".  Include "config.h" early, to ensure that HAVE_GTK etc. are defined as appropriate.

This avoids build failures with future compilers which do not support implicit function declarations.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
